### PR TITLE
fix: emojis with same name

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = class NitroBypass extends Plugin {
 			if (!emoji.require_colons) return;
 
 			// create the emoji string which we will replace
-			const emojiString = `<${emoji.animated ? 'a' : ''}:${emoji.name}:${
+			const emojiString = `<${emoji.animated ? 'a' : ''}:${emoji.originalName || emoji.name}:${
 				emoji.id
 			}>`;
 


### PR DESCRIPTION
Fixes replacing emojis with the same name across several servers, e.g.
![image](https://user-images.githubusercontent.com/55899582/162277815-ca1ce517-12b4-487d-ac52-df1d90244670.png)

In that case the message contains `<:arch:603953115099824147>` (originalName) instead of `<:arch~1:603953115099824147>` (name)