### PR TITLE
feat: spoof available emojis setting

### DIFF
--- a/components/settings.jsx
+++ b/components/settings.jsx
@@ -1,5 +1,5 @@
 const { React } = require('powercord/webpack');
-const { SliderInput } = require('powercord/components/settings');
+const { SliderInput, SwitchItem } = require('powercord/components/settings');
 
 module.exports = class NitroBypassSettings extends React.Component {
 	constructor(props) {
@@ -20,6 +20,13 @@ module.exports = class NitroBypassSettings extends React.Component {
 				>
 					Emoji size
 				</SliderInput>
+				<SwitchItem
+					note="Also replaces non-animated emojis of the current guild with links."
+					value={this.props.getSetting('spoofAvailableEmojis', false)}
+					onChange={() => this.props.toggleSetting('spoofAvailableEmojis')}
+				>
+					Spoof available emojis
+				</SwitchItem>
 			</>
 		);
 	}

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = class NitroBypass extends Plugin {
 
 		const message = await getModule(['sendMessage', 'editMessage']);
 		const currentUser = await getModule(['getCurrentUser']);
+		this.getGuildId = (await getModule(['getLastSelectedGuildId'])).getGuildId;
 
 		// spoof client side premium
 		let tries = 1;
@@ -33,10 +34,18 @@ module.exports = class NitroBypass extends Plugin {
 	emojiReplacePatch(args) {
 		const message = args[1];
 		const emojis = message.validNonShortcutEmojis;
+		const guildId = this.getGuildId();
 
 		emojis.forEach((emoji) => {
 			// skip discord emojis
 			if (!emoji.require_colons) return;
+
+			// skip available emojis
+			if (
+				!this.settings.get('spoofAvailableEmojis', false) &&
+				emoji.guildId === guildId && !emoji.animated
+			)
+				return;
 
 			// create the emoji string which we will replace
 			const emojiString = `<${emoji.animated ? 'a' : ''}:${emoji.originalName || emoji.name}:${


### PR DESCRIPTION
Added a new setting for ignoring guild emojis which are available without nitro anyways (doesn't convert to a link).
![image](https://user-images.githubusercontent.com/55899582/162526079-92b9b3d1-939d-43fe-ba21-1b2673c16133.png)
